### PR TITLE
Use custom levels folder as custom assets dir in release workflow

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -33,6 +33,7 @@ jobs:
       skipLinux: true
       toolingBinaryDir: "out/build/Release/bin"
       gameAssetsDir: "game/assets"
+      customAssetsDir: "./custom_levels"
       copyEntireBinaryDir: true
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ugly temporary workaround because mod bundler is much newer than the mod itself.